### PR TITLE
Fix plugin list not displaying on initial load of settingsPage

### DIFF
--- a/plugins/ui/src/index.tsx
+++ b/plugins/ui/src/index.tsx
@@ -22,12 +22,11 @@ radial-gradient(ellipse at top right, rgba(139, 203, 235, 0.5), transparent 70%)
 radial-gradient(ellipse at center right, rgba(98, 103, 145, 0.5), transparent 70%),
 radial-gradient(ellipse at bottom right, rgba(47, 48, 78, 0.5), transparent 70%)`;
 
-settingsPage.render(<ThemeProvider theme={lunaMuiTheme} children={<LunaPage />} />);
-
 ContextMenu.onOpen(unloads, ({ event, contextMenu }) => {
 	if (event.type === "USER_PROFILE") {
 		contextMenu.addButton("Luna Settings", (e) => {
 			e.preventDefault();
+			settingsPage.render(<ThemeProvider theme={lunaMuiTheme} children={<LunaPage />} />);
 			settingsPage.open();
 		}).style.color = "#31d8ff";
 	}


### PR DESCRIPTION
Currently, the PluginsTab in the settingsPage displays the message "You have no plugins installed!" on initial load, even when plugins are present. This happens because the tab renders immediately upon injection, before the plugin list has finished loading.