### PR TITLE
Improve Settings Tab UI + Add Version Info Component

### DIFF
--- a/plugins/ui/src/SettingsPage/SettingsTab/LunaClientUpdate.tsx
+++ b/plugins/ui/src/SettingsPage/SettingsTab/LunaClientUpdate.tsx
@@ -45,12 +45,22 @@ export const LunaClientUpdate = React.memo(() => {
 	return (
 		<LunaSettings
 			title="Client Updates"
-			desc={`Current Version: ${pkg.version}`}
 			titleChildren={<SpinningButton title="Fetch releases" loading={loading} onClick={updateReleases} />}
 			direction="row"
 			alignItems="center"
+			pb={4}
 		>
+			<Select
+				fullWidth
+				sx={{ flex: 1, height: 48 }}
+				value={selectedRelease}
+				onChange={(e) => setSelectedRelease(e.target.value)}
+				children={releases.map((release) => {
+					return <MenuItem value={release.tag_name}>{`${release.tag_name}${release.prerelease ? "-dev" : ""}`}</MenuItem>;
+				})}
+			/>
 			<LunaButton
+				sx={{ height: 48 }}
 				children={action}
 				title={desc}
 				onClick={async () => {
@@ -61,16 +71,8 @@ export const LunaClientUpdate = React.memo(() => {
 					await updateLuna(releaseUrl);
 				}}
 			/>
-			<Select
-				fullWidth
-				sx={{ flex: 1 }}
-				value={selectedRelease}
-				onChange={(e) => setSelectedRelease(e.target.value)}
-				children={releases.map((release) => {
-					return <MenuItem value={release.tag_name}>{`${release.tag_name}${release.prerelease ? "-dev" : ""}`}</MenuItem>;
-				})}
-			/>
 			<LunaButton
+				sx={{ height: 48, marginLeft: 2 }}
 				color="error"
 				children={"Factory Reset"}
 				title={"Warning! This will reset luna to a clean install with no plugins."}

--- a/plugins/ui/src/SettingsPage/SettingsTab/LunaVersionInfo.tsx
+++ b/plugins/ui/src/SettingsPage/SettingsTab/LunaVersionInfo.tsx
@@ -12,8 +12,8 @@ export const LunaVersionInfo = React.memo(() => {
 
     return (
         <div style={{ display: "flex", flexDirection: "column"}}>
-            <LunaSettings title="Version Information">
-                <div style={{ display: "flex", alignItems: "center", gap: 24, marginBottom: 16 }}>
+            <LunaSettings>
+                <div style={{ display: "flex", alignItems: "center", gap: 24, marginBottom: 8 }}>
                     <img
                         src="https://desktop.tidal.com/assets/appIcon-C2Av_5S7.png"
                         alt="TIDAL Icon"

--- a/plugins/ui/src/SettingsPage/SettingsTab/LunaVersionInfo.tsx
+++ b/plugins/ui/src/SettingsPage/SettingsTab/LunaVersionInfo.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from "react";
+import { getPackage } from "@luna/lib.native";
+import { LunaClientUpdate } from "./LunaClientUpdate";
+import { LunaSettings } from "../../components";
+
+export const LunaVersionInfo = React.memo(() => {
+    const [pkg, setPkg] = useState<{ version?: string }>({});
+
+    useEffect(() => {
+        getPackage().then(setPkg);
+    }, []);
+
+    return (
+        <div style={{ display: "flex", flexDirection: "column"}}>
+            <LunaSettings title="Version Information">
+                <div style={{ display: "flex", alignItems: "center", gap: 24, marginBottom: 16 }}>
+                    <img
+                        src="https://desktop.tidal.com/assets/appIcon-C2Av_5S7.png"
+                        alt="TIDAL Icon"
+                        style={{ width: 72, height: 72, borderRadius: 16, boxShadow: "0 2px 12px #0002" }}
+                    />
+                    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                        <h2>Thanks for using TIDALuna!</h2>
+                        <div style={{ fontSize: 18, margin: 0 }}>
+                            <strong>Version:</strong> <span style={{ color: "#31d8ff" }}>{pkg.version || "Unknown"}</span>
+                        </div>
+                    </div>
+                </div>
+                <LunaClientUpdate />
+                <div style={{ padding: 2 }}>
+                </div>
+            </LunaSettings>
+        </div>
+    );
+});

--- a/plugins/ui/src/SettingsPage/SettingsTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/SettingsTab/index.tsx
@@ -7,6 +7,7 @@ import { LunaPlugin } from "@luna/core";
 import { LunaPluginSettings } from "../PluginsTab/LunaPluginSettings";
 import { LunaClientUpdate } from "./LunaClientUpdate";
 import { LunaFeatureFlags } from "./LunaFeatureFlags";
+import { LunaVersionInfo } from "./LunaVersionInfo";
 
 export const SettingsTab = React.memo(() => {
 	const corePlugins = [];
@@ -16,7 +17,7 @@ export const SettingsTab = React.memo(() => {
 	}
 	return (
 		<Stack spacing={4}>
-			<LunaClientUpdate />
+			<LunaVersionInfo />
 			<LunaFeatureFlags />
 			<LunaSettings title="Luna core plugins" desc="Plugins providing core luna functionality">
 				{corePlugins}

--- a/plugins/ui/src/components/LunaStack.tsx
+++ b/plugins/ui/src/components/LunaStack.tsx
@@ -14,6 +14,7 @@ export const LunaStack = React.memo((props: LunaStackProps) => {
 	return (
 		<Box>
 			{title && <LunaTitle variant={variant} title={title} desc={desc} children={props.titleChildren} />}
+			<div style={{ height: 8 }} />
 			<Stack display="flex" spacing={1} {...props} />
 		</Box>
 	);


### PR DESCRIPTION
This PR includes:

A layout redesign of the LunaClientUpdate component
A new LunaVersionInfo component to display current client version info
Structural improvements to the settings tab layout

Preview of the new LunaVersionInfo component:
![image](https://github.com/user-attachments/assets/d14ed2ca-2818-4529-96ab-e4b161387795)