### PR TITLE
Fix Luna.js loading URL construction issue (#33)

### DIFF
--- a/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
@@ -29,6 +29,7 @@ addToStores("https://github.com/Aztup/luna-plugins/releases/download/latest/stor
 addToStores("https://github.com/vMohammad24/luna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/MathDesigns/luna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/otomir23/luna-plugins/releases/download/latest/store.json");
+addToStores("https://github.com/dantraynor/lunaplugins/releases/download/latest/store.json");
 
 export const PluginStoreTab = React.memo(() => {
 	const [_storeUrls, setPluginStores] = useState<string[]>(obyStore.unwrap(storeUrls));

--- a/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
@@ -29,7 +29,6 @@ addToStores("https://github.com/Aztup/luna-plugins/releases/download/latest/stor
 addToStores("https://github.com/vMohammad24/luna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/MathDesigns/luna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/otomir23/luna-plugins/releases/download/latest/store.json");
-addToStores("https://github.com/dantraynor/lunaplugins/releases/download/latest/store.json");
 
 export const PluginStoreTab = React.memo(() => {
 	const [_storeUrls, setPluginStores] = useState<string[]>(obyStore.unwrap(storeUrls));

--- a/render/src/helpers/resolvePath.ts
+++ b/render/src/helpers/resolvePath.ts
@@ -6,14 +6,46 @@
  * @returns The resolved absolute path (e.g., /folder/other.txt).
  */
 export const resolveAbsolutePath = (basePath: string, relativePath: string): string => {
-	// Create a base URL. 'file://' is a common dummy base for path manipulation.
-	// Ensure the base path ends with '/' if it represents a directory context.
-	const baseDirectory = basePath.replace(/\/[^/]*$/, "/");
-	const baseUrl = new URL(baseDirectory, "file://");
+	try {
+		// Validate inputs
+		if (!basePath || !relativePath) {
+			console.warn("[Luna.resolveAbsolutePath] Invalid input:", { basePath, relativePath });
+			return relativePath || basePath || "";
+		}
 
-	// Create a new URL by resolving the relative path against the base URL.
-	const resolvedUrl = new URL(relativePath, baseUrl);
+		// Create a base URL. 'file://' is a common dummy base for path manipulation.
+		// Ensure the base path ends with '/' if it represents a directory context.
+		const baseDirectory = basePath.replace(/\/[^/]*$/, "/");
+		
+		// Validate that baseDirectory is a valid path-like string
+		if (!baseDirectory || baseDirectory === "/") {
+			console.warn("[Luna.resolveAbsolutePath] Invalid baseDirectory:", baseDirectory);
+			return relativePath;
+		}
 
-	// Return the pathname part of the resolved URL.
-	return resolvedUrl.pathname;
+		const baseUrl = new URL(baseDirectory, "file://");
+
+		// Create a new URL by resolving the relative path against the base URL.
+		const resolvedUrl = new URL(relativePath, baseUrl);
+
+		// Return the pathname part of the resolved URL.
+		return resolvedUrl.pathname;
+	} catch (error) {
+		console.error("[Luna.resolveAbsolutePath] Failed to resolve path:", { 
+			basePath, 
+			relativePath, 
+			error: error instanceof Error ? error.message : String(error)
+		});
+		
+		// Fallback: return relativePath as-is or attempt simple concatenation
+		if (relativePath.startsWith('/')) {
+			return relativePath;
+		}
+		
+		// Simple fallback path concatenation
+		const cleanBasePath = basePath?.replace(/\/[^/]*$/, "") || "";
+		const cleanRelativePath = relativePath?.replace(/^\.\//, "") || "";
+		
+		return cleanBasePath ? `${cleanBasePath}/${cleanRelativePath}` : cleanRelativePath;
+	}
 };


### PR DESCRIPTION
## Fix Luna.js loading URL construction issue (#33)

### Problem
 - Fixes issue #33 where `resolveAbsolutePath` helper function was causing crashes with "Failed to construct 'URL': Invalid URL" errors during Luna's module loading process.

### Fix
- Add proper validation for basePath and relativePath parameters
- Add try-catch error handling around URL constructor calls
- Add fallback logic for when URL construction fails
- Add detailed error logging for debugging
- Prevent crashes when undefined/malformed paths are passed

### Testing
 - Tested with invalid input scenarios to verify graceful handling
 - Confirmed compatibility with valid inputs

Fixes: 'Failed to construct URL: Invalid URL' error
Closes #33

(accidental closure of previous PR) --> Made new fork 