### PR TITLE
Tweak Nix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,17 @@ Use one of the following projects:
 - You shouldnt need to run as Admin for installing.
 
 ### Nix install
-1. Add this flake in your inputs: `inputs.tidaLuna.url = github:Inrixia/TidaLuna`
-2. then install the package from the input: `inputs'.tidaLuna.packages.default` (with flake-parts)
+1. Add the flake in your inputs:
+```nix
+inputs.tidaLuna.url = "github:Inrixia/TidaLuna"
+```
+2. Then install the package from the input:
+```diff
+environment.systemPackages = with pkgs; [
+-  tidal-hifi
++  inputs.tidaLuna.packages.${system}.default
+];
+```
 
 ### Manual Install
 1. Download the **luna.zip** release you want to install from https://github.com/Inrixia/TidaLuna/releases


### PR DESCRIPTION
I changed the `flakeInput` to use a string instead of a URL literal. Small nitpick, but just for clarity's sake.

Also, the Nix installation didn't account for the case of `packages.default` not being exposed globally in the user's flake, which commonly is the case in multi-system flakes. So I added `${system}.` so users wouldn't have to debug this themselves.

Lastly, I clarified that a separate instance of package `tidal-hifi` isn't needed. I don't know if it's the most elegant way of showing it, but I thought it'd be better to have something that at least makes it clear.

Hopefully this is helpful. Thanks for the solid work on this project :)