### PR TITLE
build(nix): update pNPm hash & flake version

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -2,7 +2,7 @@
 stdenv.mkDerivation (finalAttrs: rec {
   name = "TidaLuna";
   pname = "${name}";
-  version = "1.6.13-beta";
+  version = "1.6.15-beta";
   src = ./..;
 
   nativeBuildInputs = [
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: rec {
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname src version;
     fetcherVersion = 1;
-    hash = "sha256-Bgmb/glatKLi5jvEYmQ9PiSywnoxMKNCTXmI9qJIONE=";
+    hash = "sha256-nfrAd+auDMqmFZdtuWyhaUJ3vrLcJHK9Ps1UNFjTDP4=";
   };
 
   buildPhase = ''


### PR DESCRIPTION
Updates the Nix flake version from 1.6.13-beta to [1.6.15-beta](https://github.com/Inrixia/TidaLuna/releases/tag/1.6.15-beta), as well as the pNPm hash from `sha256-Bgmb/glatKLi5jvEYmQ9PiSywnoxMKNCTXmI9qJIONE=` to `sha256-nfrAd+auDMqmFZdtuWyhaUJ3vrLcJHK9Ps1UNFjTDP4=` to prevent this from happening when installing:
<img width="1026" height="347" alt="image" src="https://github.com/user-attachments/assets/2aa32eb4-3742-4e3c-aa77-83e713943fe4" />

Tested by changing flake URL to my branch, works successfully!
<img width="1209" height="187" alt="image" src="https://github.com/user-attachments/assets/36c55f8e-5fb4-469f-8f3d-597fbb239b25" />
