### PR TITLE
ci: Provide static version to nix-update

### DIFF
--- a/.github/workflows/releaseDev.yml
+++ b/.github/workflows/releaseDev.yml
@@ -43,5 +43,5 @@ jobs:
      with:
       packages: nix-update
       script: |
-       nix-update --flake injection --version=unstable
+       nix-update --flake injection --version=${{ env.VERSION }}
    - uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/releaseMaster.yml
+++ b/.github/workflows/releaseMaster.yml
@@ -43,5 +43,5 @@ jobs:
      with:
       packages: nix-update
       script: |
-       nix-update --flake injection --version=unstable
+       nix-update --flake injection --version=${{ env.VERSION }}
    - uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
Turns out changes I introduced in #61 weren't compatible with `nix-update` used in release pipelines (my fault, i didnt test ci, sorry). This should fix them by explicitly providing the version that will be used by `nix-update` for the package declaration.

Fixes #73