### PR TITLE
fix: prevent race condition causing duplicate module loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.8.1-beta",
+  "version": "1.8.2-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",

--- a/render/src/exposeTidalInternals.ts
+++ b/render/src/exposeTidalInternals.ts
@@ -10,6 +10,9 @@ import { getOrCreateLoadingContainer } from "./loadingContainer";
 
 export const tidalModules: Record<string, object> = {};
 
+// Store pending promises to avoid race conditions with circular imports
+const pendingModules: Record<string, Promise<object>> = {};
+
 const fetchCode = async (path: string) => {
 	const res = await fetch(path);
 	// Include sourceURL so that dev tools shows things nicely under sources
@@ -21,17 +24,32 @@ const messageContainer = getOrCreateLoadingContainer().messageContainer;
 
 const dynamicResolve: QuartzPlugin["dynamicResolve"] = async ({ name, moduleId, config }) => {
 	const path = resolveAbsolutePath(moduleId, name);
+
+	// Return cached module if available
 	if (tidalModules[path]) return tidalModules[path];
+
+	// If already loading, wait for the same promise instead of reloading
+	if (pendingModules[path]) return pendingModules[path];
 
 	messageContainer.innerText += `Loading ${path}\n`;
 	loading++;
-	const code = await fetchCode(path);
 
-	// Load each js module and store it in the cache so we can access its exports
-	tidalModules[path] = await quartz(code, config, path);
+	// Create and store the promise BEFORE starting the async work
+	const loadPromise = (async () => {
+		const code = await fetchCode(path);
+		// Load each js module and store it in the cache so we can access its exports
+		const module = await quartz(code, config, path);
+		tidalModules[path] = module;
+		return module;
+	})();
+	pendingModules[path] = loadPromise;
+
+	const result = await loadPromise;
 	loading--;
+
+	delete pendingModules[path];
 	setTimeout(() => (document.getElementById("tidaluna-loading")!.style.opacity = "0"), 2000);
-	return tidalModules[path];
+	return result;
 };
 
 let scripts: NodeListOf<HTMLScriptElement>;
@@ -48,45 +66,59 @@ for (const script of scripts) {
 
 	const scriptContent = await fetchCode(scriptPath);
 
+	// Create and store the promise BEFORE executing quartz to prevent race conditions
+	// This ensures that if dynamicResolve is called for this module during execution,
+	// it will wait for this same promise instead of loading the module again
+	const loadPromise = (async () => {
+		const module = await quartz(
+			scriptContent,
+			{
+				// Quartz runs transform > dynamicResolve > resolve
+				plugins: [
+					{
+						transform({ code }) {
+							const actionData = findCreateActionFunction(code);
+
+							if (actionData) {
+								const { fnName, startIdx } = actionData;
+								const funcPrefix = "__LunaUnpatched_";
+								const renamedFn = funcPrefix + fnName;
+
+								// Rename the original function declaration by adding a prefix
+								// Example: `prepareAction` becomes `__LunaUnpatched_prepareAction`
+								code = code.slice(0, startIdx) + funcPrefix + code.slice(startIdx);
+
+								// Assuming the declaration starts 9 characters before the function name
+								// (e.g., accounting for "const " or "function ")
+								const declarationStartIdx = startIdx - 9;
+								const patchedDeclaration = `const ${fnName} = patchAction({ _: ${renamedFn} })._;`;
+
+								// Insert the new patched declaration before the original (now renamed) one
+								code = code.slice(0, declarationStartIdx) + patchedDeclaration + code.slice(declarationStartIdx);
+							}
+
+							return code;
+						},
+						dynamicResolve,
+						async resolve({ name, moduleId, config, accessor, store }) {
+							(store as any).exports = await dynamicResolve({ name, moduleId, config });
+							return `${accessor}.exports`;
+						},
+					},
+				],
+			},
+			scriptPath,
+		);
+		tidalModules[scriptPath] = module;
+		return module;
+	})();
+
+	// Store the promise BEFORE awaiting it
+	pendingModules[scriptPath] = loadPromise;
+
 	// Fetch, transform execute and store the module in moduleCache
 	// Hijack the Redux store & inject interceptors
-	tidalModules[scriptPath] = await quartz(
-		scriptContent,
-		{
-			// Quartz runs transform > dynamicResolve > resolve
-			plugins: [
-				{
-					transform({ code }) {
-						const actionData = findCreateActionFunction(code);
+	await loadPromise;
 
-						if (actionData) {
-							const { fnName, startIdx } = actionData;
-							const funcPrefix = "__LunaUnpatched_";
-							const renamedFn = funcPrefix + fnName;
-
-							// Rename the original function declaration by adding a prefix
-							// Example: `prepareAction` becomes `__LunaUnpatched_prepareAction`
-							code = code.slice(0, startIdx) + funcPrefix + code.slice(startIdx);
-
-							// Assuming the declaration starts 9 characters before the function name
-							// (e.g., accounting for "const " or "function ")
-							const declarationStartIdx = startIdx - 9;
-							const patchedDeclaration = `const ${fnName} = patchAction({ _: ${renamedFn} })._;`;
-
-							// Insert the new patched declaration before the original (now renamed) one
-							code = code.slice(0, declarationStartIdx) + patchedDeclaration + code.slice(declarationStartIdx);
-						}
-
-						return code;
-					},
-					dynamicResolve,
-					async resolve({ name, moduleId, config, accessor, store }) {
-						(store as any).exports = await dynamicResolve({ name, moduleId, config });
-						return `${accessor}.exports`;
-					},
-				},
-			],
-		},
-		scriptPath,
-	);
+	delete pendingModules[scriptPath];
 }


### PR DESCRIPTION
## Summary
- Add `pendingModules` cache to store promises before execution
- Prevents duplicate module loading when circular imports occur during quartz execution
- Fixes "page not found" errors at startup caused by Datadog SDK being initialized twice

## Test plan
- [x] Build succeeds
- [x] Tested locally, issue appears to be resolved