### PR TITLE
fix: themes loading, toggling, uninstalling and emergency disable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.8.5-beta",
+  "version": "1.8.6-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",

--- a/plugins/ui/src/SettingsPage/Storage.tsx
+++ b/plugins/ui/src/SettingsPage/Storage.tsx
@@ -3,10 +3,12 @@ import React from "react";
 import TextField from "@mui/material/TextField";
 
 import { debounce } from "@inrixia/helpers";
-import { LunaPlugin, ReactiveStore } from "@luna/core";
+import { ftch, LunaPlugin, ReactiveStore } from "@luna/core";
+import { StyleTag } from "@luna/lib";
 
 import { Messager } from "@luna/core";
 import type { LunaThemeStorage } from "./ThemesTab/LunaTheme";
+import { unloads } from "../index.safe";
 
 const lunaStorage = ReactiveStore.getStore("@luna/storage");
 export const storeUrls = await lunaStorage.getReactive<string[]>("storeUrls", []);
@@ -17,10 +19,53 @@ export const addToStores = (url: string) => {
 };
 
 export const themes = await lunaStorage.getReactive<Record<string, LunaThemeStorage>>("themes", {});
-export const addToThemes = (url: string) => {
+export const addToThemes = async (url: string) => {
 	if (url in themes) return false;
-	return (themes[url] ??= { enabled: true });
+	const theme = (themes[url] ??= { enabled: true });
+	// Create StyleTag and load CSS immediately
+	const styleTag = (themeStyles[url] = new StyleTag(url, unloads));
+	try {
+		const css = await ftch.text(url);
+		theme.css = css;
+		styleTag.css = css;
+		console.log("[Themes] Added and applied theme:", url);
+	} catch (e) {
+		console.error("[Themes] Failed to load theme:", url, e);
+	}
+	return theme;
 };
+
+// Apply enabled themes on startup
+export const themeStyles: Record<string, StyleTag> = {};
+for (const [url, theme] of Object.entries(themes)) {
+	if (!theme.enabled) continue;
+	console.log("[Themes] Applying theme on startup:", url);
+	const styleTag = (themeStyles[url] = new StyleTag(url, unloads));
+	if (theme.css) {
+		styleTag.css = theme.css;
+	} else {
+		ftch.text(url).then((css) => {
+			theme.css = css;
+			styleTag.css = css;
+		}).catch((e) => console.error("[Themes] Failed to load theme:", url, e));
+	}
+}
+
+// Emergency shortcut to disable all themes (Ctrl+Shift+T)
+const onEmergencyDisable = (event: KeyboardEvent) => {
+	if (event.ctrlKey && event.shiftKey && event.key === "T") {
+		let disabled = 0;
+		for (const [url, styleTag] of Object.entries(themeStyles)) {
+			if (!themes[url]?.enabled) continue;
+			styleTag.css = undefined;
+			themes[url].enabled = false;
+			disabled++;
+		}
+		if (disabled > 0) console.log(`[Themes] Emergency disable: disabled ${disabled} theme(s)`);
+	}
+};
+document.addEventListener("keydown", onEmergencyDisable);
+unloads.add(() => document.removeEventListener("keydown", onEmergencyDisable));
 
 const successSx = {
 	"& .MuiOutlinedInput-root:hover:not(.Mui-focused) .MuiOutlinedInput-notchedOutline": {
@@ -56,7 +101,7 @@ export const InstallFromUrl = React.memo(() => {
 				if (addToStores(url) === false) return setErr("Store already added");
 				successMessage = `Added store ${url}!`;
 			} else if (url.endsWith(".css")) {
-				if (addToThemes(url) === false) return setErr("Theme already added");
+				if ((await addToThemes(url)) === false) return setErr("Theme already added");
 				successMessage = `Added theme ${url}!`;
 			} else {
 				const plugin = await LunaPlugin.fromStorage({ url });

--- a/plugins/ui/src/SettingsPage/ThemesTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/ThemesTab/index.tsx
@@ -2,15 +2,15 @@ import React from "react";
 
 import Stack from "@mui/material/Stack";
 
-import { InstallFromUrl, themes } from "../Storage";
+import { InstallFromUrl, themes, themeStyles } from "../Storage";
 import { LunaTheme } from "./LunaTheme";
 
 import { store as obyStore } from "oby";
 
 export const ThemesTab = React.memo(() => {
-	const [_themes, setThemes] = React.useState(themes);
+	const [_themes, setThemes] = React.useState(() => ({ ...obyStore.unwrap(themes) }));
 	React.useEffect(() => {
-		obyStore.on(themes, () => setThemes(obyStore.unwrap(themes)));
+		obyStore.on(themes, () => setThemes({ ...obyStore.unwrap(themes) }));
 	}, []);
 	return (
 		<Stack spacing={2}>
@@ -21,7 +21,13 @@ export const ThemesTab = React.memo(() => {
 					key={url}
 					url={url}
 					uninstall={() => {
-						delete _themes[url];
+						// Remove StyleTag
+						if (themeStyles[url]) {
+							themeStyles[url].remove();
+							delete themeStyles[url];
+						}
+						// Remove from reactive store
+						delete themes[url];
 					}}
 				/>
 			))}


### PR DESCRIPTION
## Summary
- Apply enabled themes on startup instead of waiting for Themes tab render
- Fix new theme not applying immediately when added via URL
- Fix toggle enable/disable not working (use reactive store directly)
- Fix uninstall not removing theme from list (force state update)
- Add emergency shortcut (Ctrl+Shift+T) to disable all themes
- Sync UI state in real-time when themes are modified externally

## Test plan
- [x] Works for Windows & Linux