### PR TITLE
feat: add tidal-hifi sandbox compatibility layer

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -5,6 +5,7 @@
 		"type-fest": "^5.0.1"
 	},
 	"dependencies": {
+		"@electron/remote": "^2.1.3",
 		"jszip": "^3.10.1",
 		"mime": "^4.1.0"
 	}

--- a/native/tidalHifiCompat.ts
+++ b/native/tidalHifiCompat.ts
@@ -1,0 +1,82 @@
+/**
+ * tidal-hifi sandbox compatibility layer
+ * Only loaded when running on tidal-hifi (detected via package name)
+ */
+import * as electron from "electron";
+import { ipcRenderer } from "electron";
+import * as remote from "@electron/remote";
+
+// Expose process globally
+(globalThis as any).process = { platform: "linux", env: {}, cwd: () => "/", argv: [] };
+
+// Path utilities
+const path = {
+	join: (...a: string[]) => a.join("/").replace(/\/+/g, "/"),
+	dirname: (p: string) => p.split("/").slice(0, -1).join("/") || ".",
+	resolve: (base: string, rel: string) => {
+		const parts = base.split("/").filter((p) => p && p !== ".");
+		for (const p of rel.split("/")) {
+			if (p === "..") parts.pop();
+			else if (p && p !== ".") parts.push(p);
+		}
+		return parts.join("/") || ".";
+	},
+};
+
+// electron-store mock
+function Store(this: any) { this.d = {}; }
+Store.prototype = {
+	get(k: string, def?: any) { return this.d[k] ?? def; },
+	set(k: string, v: any) { this.d[k] = v; },
+	has(k: string) { return k in this.d; },
+	delete(k: string) { delete this.d[k]; },
+	clear() { this.d = {}; },
+};
+
+// Module cache for require shim
+const modules: Record<string, any> = {
+	"@electron/remote": remote,
+	electron,
+	path,
+	fs: {},
+	"electron-store": Store,
+	"mpris-service": () => ({}),
+	request: {},
+	"hotkeys-js": () => {},
+};
+
+/**
+ * Execute tidal-hifi's original preload with a custom require shim
+ */
+export const execTidalHifiPreload = async () => {
+	const cache: Record<string, any> = {};
+	const dirs = ["."];
+
+	const require = (id: string): any => {
+		if (modules[id]) return modules[id];
+		if (cache[id]) return cache[id];
+
+		if (id.startsWith("./") || id.startsWith("../")) {
+			const file = path.resolve(dirs.at(-1)!, id) + ".js";
+			if (cache[file]) return cache[file];
+
+			const res = ipcRenderer.sendSync("__Luna.readTidalModule", file);
+			if (!res.success) return {};
+
+			const mod = { exports: {} as any };
+			cache[file] = mod.exports;
+			dirs.push(path.dirname(file));
+			try {
+				new Function("require", "exports", "module", res.code)(require, mod.exports, mod);
+				cache[file] = mod.exports;
+			} finally {
+				dirs.pop();
+			}
+			return mod.exports;
+		}
+		return {};
+	};
+
+	const code = await ipcRenderer.invoke("__Luna.originalPreload");
+	new Function("require", "exports", "module", code)(require, {}, { exports: {} });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
 
   native:
     dependencies:
+      '@electron/remote':
+        specifier: ^2.1.3
+        version: 2.1.3(electron@38.7.2)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -261,6 +264,11 @@ packages:
   '@electron/get@2.0.3':
     resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
     engines: {node: '>=12'}
+
+  '@electron/remote@2.1.3':
+    resolution: {integrity: sha512-XlpxC8S4ttj/v2d+PKp9na/3Ev8bV7YWNL7Cw5b9MAWgTphEml7iYgbc7V0r9D6yDOfOkj06bchZgOZdlWJGNA==}
+    peerDependencies:
+      electron: '>= 13.0.0'
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -1484,6 +1492,10 @@ snapshots:
       global-agent: 3.0.0
     transitivePeerDependencies:
       - supports-color
+
+  '@electron/remote@2.1.3(electron@38.7.2)':
+    dependencies:
+      electron: 38.7.2
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:


### PR DESCRIPTION
## Summary
- Adds sandbox-compatible require shim for tidal-hifi's preload
- Loads @electron/remote from original.asar at runtime
- Conditionally applies only when running on tidal-hifi
- Fixes the "@electron/remote module not found" error popup on Linux

## Test plan
- [x] Windows
- [x] Linux (tidal-hifi)