### PR TITLE
fix: media keys not working

### DIFF
--- a/native/preload.ts
+++ b/native/preload.ts
@@ -1,4 +1,5 @@
-import { sleep, unloadableEmitter, type AnyFn } from "@inrixia/helpers";
+import { unloadableEmitter, type AnyFn } from "@inrixia/helpers";
+
 import { contextBridge, ipcRenderer, webFrame } from "electron";
 
 const ipcRendererUnloadable = unloadableEmitter(ipcRenderer, null, "ipcRenderer");
@@ -64,8 +65,6 @@ ipcRenderer.on("__Luna.console", (_event, prop: ConsoleMethodName, args: any[]) 
 			})()`,
 			true,
 		);
-		await sleep(0);
-		eval(await ipcRenderer.invoke("__Luna.originalPreload"));
 	} catch (err) {
 		ipcRenderer.invoke("__Luna.preloadErr", err);
 		throw err;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.9.8-beta",
+  "version": "1.9.9-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",


### PR DESCRIPTION
## Summary
- Fixes media keys not working with `sandbox:true`
- Patches original Tidal preload to use Luna's `expose` function

Closes #109

## Test plan
- [x] Works for Windows & Linux