### PR TITLE
Block tidal-hifi preload to maintain sandbox compatibility

### DIFF
--- a/native/injector.ts
+++ b/native/injector.ts
@@ -123,8 +123,14 @@ const ProxiedBrowserWindow = new Proxy(electron.BrowserWindow, {
 		if (isTidalWindow) {
 			// Luna preload via session (runs FIRST)
 			electron.session.defaultSession.setPreloads([path.join(bundleDir, "preload.mjs")]);
-			// Original preload via webPreferences (runs AFTER session preloads)
-			// Note: tidal-hifi preload uses @electron/remote which doesn't work with sandbox, so it will fail silently
+
+			// Detect and block tidal-hifi's preload (uses @electron/remote which doesn't work with sandbox)
+			const originalPreload = options.webPreferences?.preload;
+			if (originalPreload?.includes("tidal-hifi")) {
+				console.log(`[Luna.native] Blocking tidal-hifi preload: ${originalPreload}`);
+				delete options.webPreferences.preload;
+			}
+
 			options.webPreferences.sandbox = true;
 		}
 


### PR DESCRIPTION
## Summary
- Detect tidal-hifi by package name and block its preload script
- tidal-hifi's preload uses `@electron/remote` which is incompatible with `sandbox: true`

No viable solution was found to make tidal-hifi features work with sandbox enabled.
MPRIS and notifications will be implemented in TidaLuna core.
Other features are already available as Luna plugins (ListenBrainz, DiscordRPC, Themer, LastFM, etc.)

## Test plan
- [x] Tested on tidal-hifi (Linux)
- [x] No error popup on startup
- [x] Luna loads normally