### PR TITLE
Fix platform compatibility

### DIFF
--- a/native/injector.ts
+++ b/native/injector.ts
@@ -22,6 +22,12 @@ const tidalPackagePromise = readFile(path.join(tidalAppPath, "package.json"), "u
 // Requires starting client with --remote-debugging-port=9222
 electron.app.commandLine.appendSwitch("remote-allow-origins", "http://localhost:9222");
 
+// Linux sandbox fixes - must run BEFORE app is ready
+if (process.platform === "linux") {
+	// Zygote causes sandbox initialization failures on some Linux configurations
+	electron.app.commandLine.appendSwitch("no-zygote");
+}
+
 const bundleFile = async (url: string): Promise<[Buffer, ResponseInit]> => {
 	const fileName = url.slice(13);
 	// Eh, can already use native to touch fs dont stress escaping bundleDir

--- a/native/preload.ts
+++ b/native/preload.ts
@@ -40,6 +40,13 @@ ipcRenderer.on("__Luna.console", (_event, prop: ConsoleMethodName, args: any[]) 
 	try {
 		await webFrame.executeJavaScript(
 			`(async () => {
+				// Skip popup windows (login, Themer editor, etc.) - only load on TIDAL pages
+				const isTidalPage = location.hostname.includes("tidal.com");
+				if (!isTidalPage) {
+					console.log("[Luna.preload] Skipping non-TIDAL page:", location.href);
+					return;
+				}
+
 				const originalConsole = { ...console };
 				try {
 					const renderJs = await __ipcRenderer.invoke("__Luna.renderJs");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.9.14-beta",
+  "version": "1.9.15-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",


### PR DESCRIPTION
## Summary
- Add --no-zygote flag to fix Linux sandbox initialization failures
- Use platform detection to differentiate preload loading method
- Replace deprecated setPreloads with registerPreloadScript API
- Add contextIsolation for improved plugin security
- Improve console forwarding error handling
- Skip loading Luna on non-TIDAL popup windows (login, Themer editor)