### PR TITLE
Fix Linux OAuth login with popup window

### DIFF
--- a/native/injector.ts
+++ b/native/injector.ts
@@ -242,6 +242,11 @@ const ProxiedBrowserWindow = new Proxy(electron.BrowserWindow, {
 			});
 		}
 
+		// Notify renderer to unload plugins before window closes
+		window.on("close", () => {
+			window.webContents.send("window.close");
+		});
+
 		// if we are on linux and this is the main tidal window,
 		// set the icon again after load (potential KDE quirk)
 		if (platformIsLinux && isTidalWindow) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.9.15-beta",
+  "version": "1.9.16-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",

--- a/render/src/LunaPlugin.ts
+++ b/render/src/LunaPlugin.ts
@@ -70,8 +70,8 @@ export class LunaPlugin {
 	public static readonly corePlugins: Set<string> = new Set(["@luna/lib", "@luna/lib.native", "@luna/ui", "@luna/dev", "@luna/linux"]);
 
 	static {
-		// Ensure all plugins are unloaded on beforeunload
-		addEventListener("beforeunload", () => {
+		// Unload all plugins when main process signals window is closing
+		__ipcRenderer.on("window.close", () => {
 			for (const plugin of Object.values(LunaPlugin.plugins)) {
 				plugin.unload().catch((err) => {
 					const errMsg = `[Luna] Failed to unload plugin ${plugin.name}! Please report this to the Luna devs. ${err?.message}`;


### PR DESCRIPTION
## Summary
- Use popup window for OAuth flow on Linux (tidal-hifi) instead of navigating in main window
- Disable HTTPS handler during login to avoid interference with login.tidal.com
- Trigger SPA navigation via history.pushState after OAuth callback to prevent Luna plugins from reloading
- Change plugin unload from beforeunload event to IPC message for cleaner shutdown

## Test plan
- [x] Test login on Linux (tidal-hifi)
- [x] Verify plugins don't reload after login
- [x] Test logout still works (will reload page)