### PR TITLE
Fix plugin unload on close-to-tray

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.9.16-beta",
+  "version": "1.9.17-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",


### PR DESCRIPTION
## Summary
- Skip sending plugin unload IPC when closing to tray (prevents freeze)
- Use `setImmediate` to check if close event was prevented by the app
- Add try-catch in case window is already destroyed