### PR TITLE
Add fallback for Electron < 35 preload registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.9.17-beta",
+  "version": "1.9.18-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",


### PR DESCRIPTION
## Summary
- Add version check for `registerPreloadScript` API (Electron 35+)
- Fall back to legacy `setPreloads` API for older Electron versions
- Fixes crash on macOS with TIDAL versions using Electron < 35