### PR TITLE
Remove obsolete CLEAR_QUEUE interception

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.9.18-beta",
+  "version": "1.9.19-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",

--- a/plugins/lib/src/classes/PlayState.ts
+++ b/plugins/lib/src/classes/PlayState.ts
@@ -183,32 +183,6 @@ export class PlayState {
 			}
 		});
 
-		// Preserve current track when clearing queue (manual clear only, not when playing new content)
-		let blockAutoPlay = false;
-		let blockTimeout: ReturnType<typeof setTimeout> | undefined;
-		const playActions = ["playbackControls/PLAY", "mix/PLAY_MIX", "playQueue/ADD_NOW", "playQueue/ADD_TRACK_LIST_TO_PLAY_QUEUE"] as const;
-		for (const action of playActions) {
-			redux.intercept(action, unloads, (payload: { overwritePlayQueue?: boolean }) => {
-				// Allow if it's explicit new content (user playing something new)
-				if (payload?.overwritePlayQueue === true) return false;
-				return blockAutoPlay;
-			});
-		}
-
-		redux.intercept("playQueue/CLEAR_QUEUE", unloads, () => {
-			const { elements, currentIndex } = this.playQueue;
-			const currentElement = elements[currentIndex];
-			if (!currentElement) return;
-
-			blockAutoPlay = true;
-			clearTimeout(blockTimeout);
-			redux.actions["playbackControls/STOP"]();
-			redux.actions["view/HIDE_PLAY_QUEUE_ASIDE"]();
-			redux.actions["playQueue/RESET"]({ elements: [currentElement], currentIndex: 0 });
-			blockTimeout = setTimeout(() => (blockAutoPlay = false), 1000);
-
-			return true;
-		});
 	}
 
 	private static currentMediaItem?: MediaItem;


### PR DESCRIPTION
## Summary
- Remove `CLEAR_QUEUE` interception workaround that is no longer needed

## Context
TIDAL changed the behavior of the "Clear Queue" button. Previously, clearing the queue would also stop the currently playing music and close the player entirely. A workaround was added to intercept this action and preserve the current track.

Now, the "Clear Queue" button only appears when the user has added tracks to the queue, and it only removes those queued tracks without affecting the currently playing music.

This workaround is no longer necessary and was causing issues elsewhere, such as blocking playback from "Recommended new tracks" and similar sections.

Closes #122