### PR TITLE
Fix DEV plugins store handling

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -47,7 +47,7 @@ export const pluginBuildOptions = async (pluginPath: string, opts?: BuildOptions
 					module.exports = luna?.core?.modules?.["${module}"];
 					if (module.exports === undefined) throw new Error("Cannot find module ${module} in luna.core.modules");
 					// Icky but it works
-					luna.core.LunaPlugin.plugins["${module}"]?.addDependant(luna.core.LunaPlugin.plugins["${pkgName}"]);
+					luna.core.LunaPlugin.getByName("${module}")?.addDependant(luna.core.LunaPlugin.getByName("${pkgName}"));
 				`,
 			}),
 			fileUrlPlugin,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.9.21-beta",
+  "version": "1.9.22-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",

--- a/plugins/ui/src/SettingsPage/PluginsTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/PluginsTab/index.tsx
@@ -7,9 +7,11 @@ import { LunaPluginSettings } from "./LunaPluginSettings";
 
 export const PluginsTab = React.memo(() => {
 	const plugins = [];
-	for (const pluginName in LunaPlugin.plugins) {
-		if (LunaPlugin.corePlugins.has(pluginName)) continue;
-		plugins.push(<LunaPluginSettings key={pluginName} plugin={LunaPlugin.plugins[pluginName]} />);
+	for (const plugin of Object.values(LunaPlugin.plugins)) {
+		if (LunaPlugin.corePlugins.has(plugin.name)) continue;
+		// Only show installed plugins (not store display instances)
+		if (!plugin.installed) continue;
+		plugins.push(<LunaPluginSettings key={plugin.url} plugin={plugin} />);
 	}
 	if (plugins.length === 0) return "You have no plugins installed!";
 	return <Stack spacing={2}>{plugins}</Stack>;

--- a/plugins/ui/src/SettingsPage/SettingsTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/SettingsTab/index.tsx
@@ -10,9 +10,9 @@ import { LunaVersionInfo } from "./LunaVersionInfo";
 
 export const SettingsTab = React.memo(() => {
 	const corePlugins = [];
-	for (const pluginName in LunaPlugin.plugins) {
-		if (!LunaPlugin.corePlugins.has(pluginName)) continue;
-		corePlugins.push(<LunaPluginSettings key={pluginName} plugin={LunaPlugin.plugins[pluginName]} />);
+	for (const plugin of Object.values(LunaPlugin.plugins)) {
+		if (!LunaPlugin.corePlugins.has(plugin.name)) continue;
+		corePlugins.push(<LunaPluginSettings key={plugin.url} plugin={plugin} />);
 	}
 	return (
 		<Stack spacing={4}>


### PR DESCRIPTION
## Summary
- Index plugins by URL instead of name, allowing multiple versions (DEV + GitHub) of the same plugin to be displayed
- DEV plugins persist when installed, just like GitHub plugins
- Add `getByName()` and `getAllByName()` methods for backwards-compatible access by name
- Add `[DEV]` suffix to trace logs for easier debugging
- Handle switching between plugin versions cleanly (uninstalls other versions on install)

Closes #119