### PR TITLE
Fix crash on app close with Wayland (KDE/GNOME)

### DIFF
--- a/native/injector.ts
+++ b/native/injector.ts
@@ -301,7 +301,7 @@ const ProxiedBrowserWindow = new Proxy(electron.BrowserWindow, {
 						// Call the original console method
 						(originalValue as Function).apply(target, args);
 						// Send the log data to the renderer process (if still alive)
-						if (rendererAlive && !window.webContents.isDestroyed()) {
+						if (rendererAlive && !window.isDestroyed() && !window.webContents.isDestroyed()) {
 							try {
 								window.webContents.send("__Luna.console", prop.toString(), args);
 							} catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.9.19-beta",
+  "version": "1.9.20-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",


### PR DESCRIPTION
## Summary
Add `window.isDestroyed()` check before accessing `webContents` in the console proxy.

On Wayland (tested on CachyOS with KDE), the BrowserWindow can be destroyed before the `render-process-gone` event fires, causing a `TypeError: Object has been destroyed` when trying to access `webContents` during cleanup.