### PR TITLE
Add openExternal to lib.native

### DIFF
--- a/native/expose.ts
+++ b/native/expose.ts
@@ -1,5 +1,6 @@
-import { clipboard, dialog } from "electron";
+import { clipboard, dialog, shell } from "electron";
 export const clipboardWriteText = clipboard.writeText;
+export const openExternal = shell.openExternal;
 export const showOpenDialog = dialog.showOpenDialog;
 export const showSaveDialog = dialog.showSaveDialog;
 export const showMessageBox = dialog.showMessageBox;

--- a/plugins/lib.native/src/native.ts
+++ b/plugins/lib.native/src/native.ts
@@ -9,3 +9,4 @@ export const showSaveDialog = luna.showSaveDialog;
 export const showMessageBox = luna.showMessageBox;
 export const showErrorBox = luna.showErrorBox;
 export const clipboardWriteText = luna.clipboardWriteText;
+export const openExternal = luna.openExternal;


### PR DESCRIPTION
## Summary
- Expose `shell.openExternal` for plugins to open URLs in system browser
- Useful for plugins that need to open auth URLs (e.g., LastFM on Linux where Electron popups don't work properly)