### PR TITLE
Fix scrobble not triggering on repeat mode and end of queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.9.20-beta",
+  "version": "1.9.21-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",


### PR DESCRIPTION
## Summary
- Scrobble now triggers when a song loops in repeat mode
- Scrobble now triggers when playback ends (no next track)

Closes https://github.com/Inrixia/luna-plugins/issues/207