### PR TITLE
Add Linux elevated update via pkexec/kdesudo

### DIFF
--- a/native/injector.ts
+++ b/native/injector.ts
@@ -217,7 +217,7 @@ const ProxiedBrowserWindow = new Proxy(electron.BrowserWindow, {
 
 		const window = new target(options);
 
-		globalThis.luna.sendToRender = window.webContents.send;
+		globalThis.luna.sendToRender = window.webContents.send.bind(window.webContents);
 
 		// Linux (tidal-hifi): Handle OAuth login in a popup window
 		if (platformIsLinux) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.10.0-beta",
+  "version": "1.11.0-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",

--- a/plugins/lib.native/src/native.ts
+++ b/plugins/lib.native/src/native.ts
@@ -1,6 +1,8 @@
 export const pkg = luna.pkg;
 export const update = luna.update;
 export const relaunch = luna.relaunch;
+export const needsElevation = luna.needsElevation;
+export const runElevatedInstall = luna.runElevatedInstall;
 export const sendToRender = luna.sendToRender;
 
 // Electron

--- a/plugins/ui/src/SettingsPage/SettingsTab/LunaClientUpdate.tsx
+++ b/plugins/ui/src/SettingsPage/SettingsTab/LunaClientUpdate.tsx
@@ -4,10 +4,14 @@ import React from "react";
 import { components } from "@octokit/openapi-types";
 type GitHubRelease = components["schemas"]["release"];
 
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 
-import { pkg, relaunch, update } from "plugins/lib.native/src/index.native";
+import { pkg, relaunch, update, needsElevation, runElevatedInstall } from "plugins/lib.native/src/index.native";
 
 export const version = (await pkg()).version;
 
@@ -20,6 +24,7 @@ export const LunaClientUpdate = React.memo(() => {
 	const confirm = useConfirm();
 	const [releases, setReleases] = React.useState<GitHubRelease[]>([]);
 	const [loading, setLoading] = React.useState(false);
+	const [busy, setBusy] = React.useState<"updating" | "resetting" | null>(null);
 	const [selectedRelease, setSelectedRelease] = React.useState<string>(version!);
 
 	const updateReleases = async () => {
@@ -51,6 +56,12 @@ export const LunaClientUpdate = React.memo(() => {
 			alignItems="center"
 			pb={4}
 		>
+			<Dialog open={!!busy}>
+				<DialogTitle>Operation in progress</DialogTitle>
+				<DialogContent>
+					<DialogContentText>Please do not close the application. It will restart automatically.</DialogContentText>
+				</DialogContent>
+			</Dialog>
 			<Select
 				fullWidth
 				sx={{ flex: 1, height: 48 }}
@@ -62,6 +73,7 @@ export const LunaClientUpdate = React.memo(() => {
 			/>
 			<LunaButton
 				sx={{ height: 48 }}
+				disabled={!!busy}
 				children={action}
 				title={desc}
 				onClick={async () => {
@@ -69,12 +81,52 @@ export const LunaClientUpdate = React.memo(() => {
 					if (!result.confirmed) return;
 					const releaseUrl = releases.find((r) => r.tag_name === selectedRelease)?.assets[0].browser_download_url;
 					if (releaseUrl === undefined) throw new Error("Release URL not found");
-					await update(selectedRelease);
+
+					// On Linux, warn the user if elevation is needed
+					if (__platform === "linux" && (await needsElevation())) {
+						const elevationResult = await confirm({
+							title: "Administrator privileges required",
+							description:
+								"TidaLuna does not have write access to the installation directory. " +
+								"Your password will be requested to proceed with the update.",
+							confirmationText: "Continue",
+							cancellationText: "Cancel",
+						});
+						if (!elevationResult.confirmed) return;
+					}
+
+					const updateResult = await update(selectedRelease);
+
+					if (updateResult === "elevation_required") {
+						setBusy("updating");
+						try {
+							await runElevatedInstall();
+						} catch (err: any) {
+							setBusy(null);
+							if (err.message?.includes("ELEVATION_CANCELLED")) return;
+							if (err.message?.includes("NO_ELEVATION_TOOL")) {
+								await confirm({
+									title: "Elevation failed",
+									description:
+										"Neither pkexec nor kdesudo were found on your system. " +
+										"Please perform this operation manually.",
+									hideCancelButton: true,
+								});
+								return;
+							}
+							throw err;
+						}
+					}
+
+					setBusy("updating");
+					await new Promise((resolve) => setTimeout(resolve, 2000));
+					await relaunch();
 				}}
 			/>
 			<LunaButton
 				sx={{ height: 48, marginLeft: 2 }}
 				color="error"
+				disabled={!!busy}
 				children={"Factory Reset"}
 				title={"Warning! This will reset luna to a clean install with no plugins."}
 				onClick={async () => {
@@ -85,6 +137,7 @@ export const LunaClientUpdate = React.memo(() => {
 					});
 					if (!ok.confirmed) return;
 
+					setBusy("resetting");
 					for (const db of await indexedDB.databases()) {
 						// Dont delete the tidal localforage db as it will reset the tidal app
 						// Deleting other _TIDAL indexedDB databases is ok


### PR DESCRIPTION
## Summary
- Detect write permission on app folder (`W_OK`) and prompt user for elevation when needed
- Elevate via `pkexec` with `kdesudo` fallback, handle cancellation (code 126) and missing tools
- Show MUI `Dialog` during update operation to prevent user interaction
- Move `update` from native bridge (`luna.update`) to dedicated IPC channel to prevent plugin abuse
- Validate app folder path before any elevated operation (path traversal protection)

https://github.com/user-attachments/assets/629c7629-b71c-4206-8fd9-b31c97c907b1