### PR TITLE
Add search filter to plugin store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.11.0-beta",
+  "version": "1.12.0-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",

--- a/plugins/ui/src/SettingsPage/PluginStoreTab/LunaStore.tsx
+++ b/plugins/ui/src/SettingsPage/PluginStoreTab/LunaStore.tsx
@@ -14,7 +14,7 @@ interface StorePackage extends PluginPackage {
 	plugins: string[];
 }
 
-export const LunaStore = React.memo(({ url, onRemove }: { url: string; onRemove: () => void }) => {
+export const LunaStore = React.memo(({ url, onRemove, searchQuery }: { url: string; onRemove: () => void; searchQuery: string }) => {
 	const [loading, setLoading] = React.useState(false);
 	const [loadError, setLoadError] = React.useState<string | undefined>(undefined);
 	const [pkg, setPackage] = React.useState<StorePackage | undefined>(undefined);
@@ -58,6 +58,10 @@ export const LunaStore = React.memo(({ url, onRemove }: { url: string; onRemove:
 	// Don't show error for local dev store
 	if (loadError && isLocalDevStore) return null;
 
+	const query = searchQuery.toLowerCase();
+	const filteredPlugins = query ? pkg?.plugins.filter((plugin) => plugin.toLowerCase().includes(query)) : pkg?.plugins;
+	if (query && (!filteredPlugins || filteredPlugins.length === 0)) return null;
+
 	return (
 		<Stack
 			spacing={1}
@@ -82,7 +86,7 @@ export const LunaStore = React.memo(({ url, onRemove }: { url: string; onRemove:
 				}
 			/>
 			<Grid columns={2} spacing={2} container>
-				{pkg?.plugins.map((plugin) => (
+				{filteredPlugins?.map((plugin) => (
 					<Grid size={1} children={<LunaStorePlugin url={`${url}/${isLocalDevStore ? plugin : plugin.replace(" ", ".")}`} key={plugin} />} />
 				))}
 			</Grid>

--- a/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
@@ -5,6 +5,7 @@ import { store as obyStore } from "oby";
 import { ReactiveStore } from "@luna/core";
 
 import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
 
 import { InstallFromUrl } from "./InstallFromUrl";
 import { LunaStore } from "./LunaStore";
@@ -39,6 +40,7 @@ addToStores("https://github.com/SinnerK0N/tidaluna-plugins/releases/download/lat
 
 export const PluginStoreTab = React.memo(() => {
 	const [_storeUrls, setPluginStores] = useState<string[]>(obyStore.unwrap(storeUrls));
+	const [searchQuery, setSearchQuery] = useState("");
 
 	useEffect(() => obyStore.on(storeUrls, () => setPluginStores([...obyStore.unwrap(storeUrls)])), []);
 	const onRemove = useCallback((storeUrl: string) => {
@@ -48,10 +50,19 @@ export const PluginStoreTab = React.memo(() => {
 
 	return (
 		<Stack spacing={2}>
-			<InstallFromUrl />
-			<LunaStore url={"http://127.0.0.1:3000"} onRemove={() => {}} />
+			<Stack direction="row" spacing={2}>
+				<InstallFromUrl />
+				<TextField
+					fullWidth
+					size="small"
+					placeholder="Search plugins..."
+					value={searchQuery}
+					onChange={(e) => setSearchQuery(e.target.value)}
+				/>
+			</Stack>
+			<LunaStore url={"http://127.0.0.1:3000"} onRemove={() => {}} searchQuery={searchQuery} />
 			{_storeUrls.map((store) => (
-				<LunaStore key={store} url={store} onRemove={() => onRemove(store)} />
+				<LunaStore key={store} url={store} onRemove={() => onRemove(store)} searchQuery={searchQuery} />
 			))}
 		</Stack>
 	);


### PR DESCRIPTION
## Summary
- Add a search TextField next to the Install from URL input
- Filter plugins by name in real-time (case-insensitive)
- Hide stores with no matching plugins when searching

<img width="839" height="833" alt="TIDAL_xvxGqgUNEc" src="https://github.com/user-attachments/assets/0c969bd3-6a8a-4feb-b85a-06b8e5dba62a" />