### PR TITLE
Enhance native module security

### DIFF
--- a/native/NativeModule/secureLoad.ts
+++ b/native/NativeModule/secureLoad.ts
@@ -117,7 +117,7 @@ export const secureLoad = (moduleInfo: NativeModuleInfo): Module["exports"] => {
 		nextTick: (...args: Parameters<typeof process.nextTick>) => process.nextTick(...args),
 		hrtime: (time?: [number, number]) => process.hrtime(time),
 		...objectify({
-			env: process.env,
+			env: {},
 			version: process.version,
 			versions: process.versions,
 			platform: process.platform,
@@ -132,7 +132,7 @@ export const secureLoad = (moduleInfo: NativeModuleInfo): Module["exports"] => {
 		resourcesPath: process.resourcesPath,
 
 		cwd: () => process.cwd(),
-		argv: process.argv,
+		argv: Object.freeze([...process.argv]),
 
 		debugProcess: () => {
 			// @ts-expect-error This exists

--- a/native/expose.ts
+++ b/native/expose.ts
@@ -1,6 +1,9 @@
 import { clipboard, dialog, shell } from "electron";
 export const clipboardWriteText = clipboard.writeText;
-export const openExternal = shell.openExternal;
+export const openExternal = (url: string) => {
+	if (!/^https?:\/\//i.test(url)) throw new Error(`[🛑Security🛑] openExternal blocked: only http/https allowed, got "${url}"`);
+	return shell.openExternal(url);
+};
 export const showOpenDialog = dialog.showOpenDialog;
 export const showSaveDialog = dialog.showSaveDialog;
 export const showMessageBox = dialog.showMessageBox;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.12.1-beta",
+  "version": "1.12.2-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",


### PR DESCRIPTION
## Summary
- Harden native sandbox: block process.env, freeze process.argv
- Block path traversal in bundle protocol handler and theme CSS reader
- Escape OAuth redirect path in executeJavaScript to prevent JS injection
- Add Zip Slip validation and cryptographic random temp file for elevated updates
- Restrict openExternal to http/https protocols only

None of these changes should affect existing plugin functionality. Patches can follow if needed.

## Details

**Sandbox (secureLoad.ts)**
- `process.env` was exposed, allowing plugins to read API keys/tokens → now empty object
- `process.argv` was a mutable direct reference → now frozen copy

**Path traversal (injector.ts)**
- Bundle protocol handler allowed `../../` to read arbitrary files
- Theme CSS reader had the same issue on both user and resources paths
- OAuth redirect path was interpolated without escaping in executeJavaScript

**Elevated updates (update.ts)**
- System `unzip` with root privileges had no Zip Slip protection → entries validated before extraction
- Temp file used predictable `Date.now()` name → replaced with `randomBytes(16)`

**Native bridge (expose.ts)**
- `openExternal` accepted any protocol (file://, smb://) → restricted to http/https