### PR TITLE
feat: add darwin support to nix flake

### DIFF
--- a/nix/darwin-tidal.nix
+++ b/nix/darwin-tidal.nix
@@ -1,0 +1,64 @@
+{
+  prev ? { },
+  injection,
+  tidalDmg,
+}:
+let
+  inherit (prev) lib stdenv;
+in
+stdenv.mkDerivation {
+  pname = "tidaLuna-darwin";
+  version = "1";
+
+  buildPhase = ''
+    true
+  '';
+
+  # Use a no-op unpackPhase so the build doesn't try to unpack anything.
+  unpackPhase = ": ";
+
+  allowedPlatforms = lib.platforms.darwin;
+
+  installPhase = ''
+    # Ensure the macOS tool `hdiutil` exists at `/usr/bin/hdiutil`. Nix builder
+    # environments can have a restricted PATH, so check the absolute path and
+    # fail with a clear message if it's not available.
+    if [ ! -x /usr/bin/hdiutil ]; then
+      echo "/usr/bin/hdiutil not found or not executable; build this on macOS host."
+      exit 1
+    fi
+
+    mkdir -p "$out/Applications"
+
+    MOUNT_POINT=$(mktemp -d)
+    /usr/bin/hdiutil attach '${tidalDmg}' -nobrowse -mountpoint "$MOUNT_POINT"
+
+    if [ -d "$MOUNT_POINT/TIDAL.app" ]; then
+      cp -R "$MOUNT_POINT/TIDAL.app" "$out/Applications/TIDAL.app"
+    else
+      APP_PATH=$(find "$MOUNT_POINT" -name "TIDAL.app" -maxdepth 2 -print -quit)
+      if [ -n "$APP_PATH" ]; then
+        cp -R "$APP_PATH" "$out/Applications/TIDAL.app"
+      else
+        echo "TIDAL.app not found in DMG"
+      fi
+    fi
+
+    /usr/bin/hdiutil detach "$MOUNT_POINT"
+
+    if [ -f "$out/Applications/TIDAL.app/Contents/Resources/app.asar" ]; then
+      mv "$out/Applications/TIDAL.app/Contents/Resources/app.asar" "$out/Applications/TIDAL.app/Contents/Resources/original.asar" || true
+    fi
+
+    mkdir -p "$out/Applications/TIDAL.app/Contents/Resources/app/"
+    cp -R ${injection}/* "$out/Applications/TIDAL.app/Contents/Resources/app/"
+  '';
+
+  meta = with lib; {
+    description = "TidaLuna macOS TIDAL DMG wrapper";
+    platforms = [
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/nix/injection.nix
+++ b/nix/injection.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (rec {
   pnpmDeps = fetchPnpmDeps {
     inherit pname src version;
     fetcherVersion = 1;
-    hash = "sha256-Oj34rQbKbsHnqPdVv+ti8z+gZTT+VOsDxg/MQ22sLRQ=";
+    hash = "sha256-pHIY4Ie66ZVwEne/4RmY2QvsRWcnfsl2kv3CDXcqVrg=";
   };
 
   buildPhase = ''

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,15 +1,34 @@
 {
+  lib,
+  stdenv,
   callPackage,
-  tidal-hifi
-}:
-let
-  injection = callPackage ./injection.nix { };
-in
-  tidal-hifi.overrideAttrs rec {
-     postInstall = ''
-       mv $out/share/tidal-hifi/resources/app.asar $out/share/tidal-hifi/resources/original.asar
+  fetchurl,
+  tidal-hifi ? null,
+}: let
+  injection = callPackage ./injection.nix {};
 
-       mkdir -p "$out/share/tidal-hifi/resources/app/"
-       cp -R ${injection}/* $out/share/tidal-hifi/resources/app/
-     '';
-  }
+  # Only fetch the DMG for darwin builds
+  tidalDmg =
+    if stdenv.isDarwin
+    then
+      fetchurl {
+        url = "https://download.tidal.com/desktop/TIDAL.arm64.dmg";
+        sha256 = "sha256-w5tQscUkhxpWOToAP4oIJJstCNFIdosebTyDI1zFIAE=";
+      }
+    else null;
+in
+  if stdenv.isDarwin
+  then
+    import ./darwin-tidal.nix {
+      prev = {inherit lib stdenv;};
+      inherit injection tidalDmg;
+    }
+  else
+    tidal-hifi.overrideAttrs rec {
+      postInstall = ''
+        mv $out/share/tidal-hifi/resources/app.asar $out/share/tidal-hifi/resources/original.asar
+
+        mkdir -p "$out/share/tidal-hifi/resources/app/"
+        cp -R ${injection}/* $out/share/tidal-hifi/resources/app/
+      '';
+    }


### PR DESCRIPTION
This pull requests adds macOS support to the nix flake. `nix/darwin-tidal.nix` installs the official tidal client and then injects the new asar file as described in the readme.