### PR TITLE
Fix Luna not loading on SPA deep links

### DIFF
--- a/native/preload.ts
+++ b/native/preload.ts
@@ -40,11 +40,10 @@ ipcRenderer.on("__Luna.console", (_event, prop: ConsoleMethodName, args: any[]) 
 	try {
 		await webFrame.executeJavaScript(
 			`(async () => {
-				// Skip popup windows (login, Themer editor, etc.) and non-SPA pages (magazine, etc.)
-				// Only load on the main TIDAL SPA entry point (pathname "/")
-				const isTidalApp = location.hostname.includes("tidal.com") && location.pathname === "/";
-				if (!isTidalApp) {
-					console.log("[Luna.preload] Skipping non-TIDAL app page:", location.href);
+				// Check with the main process if this page was processed by Luna's HTTPS handler
+				const isLunaPage = await __ipcRenderer.invoke("__Luna.isLunaPage", location.href);
+				if (!isLunaPage) {
+					console.log("[Luna.preload] Skipping non-Luna page:", location.href);
 					return;
 				}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.12.2-beta",
+  "version": "1.12.3-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",


### PR DESCRIPTION
## Summary
The `pathname === "/"` check in both the HTTPS handler and preload prevented Luna from loading when the app navigates directly to a SPA route (e.g. `/my-collection/tracks`).

This replaces it with an IPC-based approach:
- The HTTPS handler tracks which pages it processed (verified via Content-Type and CSP meta tag presence)
- The preload queries the main process via `__Luna.isLunaPage` before loading
- Non-SPA pages (magazine, settings) are naturally excluded since they don't contain Tidal's CSP meta tag