### PR TITLE
Fix sandbox env blocking DiscordRPC and IPC sockets

### DIFF
--- a/native/NativeModule/secureLoad.ts
+++ b/native/NativeModule/secureLoad.ts
@@ -117,7 +117,11 @@ export const secureLoad = (moduleInfo: NativeModuleInfo): Module["exports"] => {
 		nextTick: (...args: Parameters<typeof process.nextTick>) => process.nextTick(...args),
 		hrtime: (time?: [number, number]) => process.hrtime(time),
 		...objectify({
-			env: {},
+			env: Object.freeze(Object.fromEntries(
+				["TMPDIR", "TMP", "TEMP", "XDG_RUNTIME_DIR", "HOME", "USERPROFILE", "PATH", "APPDATA"]
+					.filter((k) => k in process.env)
+					.map((k) => [k, process.env[k]]),
+			)),
 			version: process.version,
 			versions: process.versions,
 			platform: process.platform,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.12.3-beta",
+  "version": "1.12.4-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",


### PR DESCRIPTION
## Summary
Fixes https://github.com/Inrixia/luna-plugins/issues/221. The empty `env: {}` in the native sandbox prevented plugins from reading `TMPDIR`/`XDG_RUNTIME_DIR`, which Discord RPC needs to locate IPC sockets. Replaced with a frozen whitelist of safe system path variables (`TMPDIR`, `TMP`, `TEMP`, `XDG_RUNTIME_DIR`, `HOME`, `USERPROFILE`, `PATH`, `APPDATA`).