### PR TITLE
Fix module resolution and action patching for new Tidal bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.12.6-beta",
+  "version": "1.12.7-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",

--- a/render/src/helpers/findCreateAction.ts
+++ b/render/src/helpers/findCreateAction.ts
@@ -1,11 +1,13 @@
 /**
  * Finds the name and index of https://redux-toolkit.js.org/api/createAction
  * based on the presence of (`.payload,..."meta"in `) commonly found in Redux Toolkit's `createAction`.
+ * Quote-agnostic — some bundlers convert string delimiters to backticks.
  */
 export function findCreateActionFunction(code: string): { fnName: string; startIdx: number } | null {
-	// Search for the specific pattern indicating a prepare callback structure.
-	const payloadMetaIndex = code.indexOf(`.payload,..."meta"in `);
-	if (payloadMetaIndex === -1) return null;
+	// Match .payload,..."meta"in with any quote style (", ', `)
+	const payloadMetaMatch = code.match(/\.payload,\.{3}(?:"|'|`)meta(?:"|'|`)in /);
+	if (!payloadMetaMatch) return null;
+	const payloadMetaIndex = payloadMetaMatch.index!;
 
 	// Find the start of the function definition preceding the pattern.
 	const codeBeforePattern = code.slice(0, payloadMetaIndex);

--- a/render/src/modules.ts
+++ b/render/src/modules.ts
@@ -1,5 +1,7 @@
 import type { Store } from "redux";
 import { findModuleByProperty } from "./helpers/findModule";
+import { tidalModules } from "./exposeTidalInternals";
+import { coreTrace } from "./trace/Tracer";
 
 export const modules: Record<string, any> = {};
 
@@ -13,15 +15,34 @@ window.require.main = undefined;
 
 export const reduxStore: Store = findModuleByProperty((key, value) => key === "replaceReducer" && typeof value === "function")!;
 
+// Tidal's bundler wraps CJS modules (React, ReactDOM, jsx-runtime) in lazy loaders
+// and minifies export names. Find the chunk by path, invoke the lazy loader, validate the result.
+const resolveCjsModule = (pathPattern: RegExp, validator: (r: any) => boolean) => {
+	for (const [path, mod] of Object.entries(tidalModules)) {
+		if (!pathPattern.test(path)) continue;
+		for (const value of Object.values(mod)) {
+			if (typeof value !== "function") continue;
+			const src = Function.prototype.toString.call(value);
+			if (!src.includes("{exports:{}") || !src.includes(".exports")) continue;
+			try {
+				const result = value();
+				if (result && typeof result === "object" && validator(result)) return result;
+			} catch {}
+		}
+	}
+};
+
 // Expose react
-modules["react"] = findModuleByProperty((key, value) => key === "createElement" && typeof value === "function");
-modules["react"].default ??= modules["react"];
+const react = resolveCjsModule(/\/react-(?!dom[-.])[^/]+\.js$/, (r) => typeof r.useState === "function" && typeof r.useEffect === "function");
+if (react) { react.default ??= react; modules["react"] = react; }
+else { coreTrace.warn("modules", "Failed to resolve React module"); }
 
-modules["react/jsx-runtime"] = findModuleByProperty((key, value) => key === "jsx" && typeof value === "function");
-modules["react/jsx-runtime"].default ??= modules["react/jsx-runtime"];
+const jsxRT = resolveCjsModule(/\/jsx-runtime-[^/]+\.js$/, (r) => typeof r.jsx === "function" && typeof r.jsxs === "function");
+if (jsxRT) { jsxRT.default ??= jsxRT; modules["react/jsx-runtime"] = jsxRT; }
+else { coreTrace.warn("modules", "Failed to resolve react/jsx-runtime module"); }
 
-// Expose react-dom
-modules["react-dom/client"] = findModuleByProperty((key, value) => key === "createRoot" && typeof value === "function");
-modules["react-dom/client"].default ??= modules["react-dom/client"];
+const reactDom = resolveCjsModule(/\/react-dom-[^/]+\.js$/, (r) => typeof r.createRoot === "function" && typeof r.hydrateRoot === "function");
+if (reactDom) { reactDom.default ??= reactDom; modules["react-dom/client"] = reactDom; }
+else { coreTrace.warn("modules", "Failed to resolve react-dom/client module"); }
 
 modules["oby"] = await import("oby");


### PR DESCRIPTION
## Summary
- Tidal updated their web app bundle — CJS modules (React, ReactDOM, jsx-runtime) are now wrapped in lazy loaders with minified export names, breaking `findModuleByProperty`. New resolution finds chunks by path pattern, detects CJS lazy loaders via `toString()`, calls them, and validates the returned exports.
- String literals are now backtick-quoted throughout the bundle, breaking the `createAction` pattern detection. Replaced `indexOf` with a quote-agnostic regex.

Fixes https://github.com/Inrixia/TidaLuna/issues/153