### PR TITLE
nix: migrate fetchPnpmDeps

### DIFF
--- a/nix/injection-darwin.nix
+++ b/nix/injection-darwin.nix
@@ -20,7 +20,7 @@ in
 
     pnpmDeps = fetchPnpmDeps {
       inherit pname src version;
-      fetcherVersion = 1;
+      fetcherVersion = 3;
       hash = "sha256-n3S7IzTTCoJdA80lmy5mQ2RJ7fj1EF7nk+oBcGTwYRM=";
     };
 

--- a/nix/injection-linux.nix
+++ b/nix/injection-linux.nix
@@ -20,8 +20,8 @@ in
 
     pnpmDeps = fetchPnpmDeps {
       inherit pname src version;
-      fetcherVersion = 1;
-      hash = "sha256-XJqU8RkNHq/RS9kSbgtuSlZZ+1ZoLk0rYnW+G268KxQ=";
+      fetcherVersion = 3;
+      hash = "sha256-HhBLCc77SzaG7way8LR8mMGEp0cyuUHqUa8CxKUBDTY=";
     };
 
     buildPhase = ''


### PR DESCRIPTION
This fixes a warning see: https://github.com/NixOS/nixpkgs/issues/494184

~~Did not do it for Darwin as I do not have access to that platform.~~