### PR TITLE
nix: fix stale Darwin pnpmDeps hash after fetcherVersion 3 migration

### DIFF
--- a/nix/injection-darwin.nix
+++ b/nix/injection-darwin.nix
@@ -21,7 +21,7 @@ in
     pnpmDeps = fetchPnpmDeps {
       inherit pname src version;
       fetcherVersion = 3;
-      hash = "sha256-n3S7IzTTCoJdA80lmy5mQ2RJ7fj1EF7nk+oBcGTwYRM=";
+      hash = "sha256-HhBLCc77SzaG7way8LR8mMGEp0cyuUHqUa8CxKUBDTY=";
     };
 
     buildPhase = ''


### PR DESCRIPTION
Ya forgot to update the hash <3