### PR TITLE
Add store: TIDAL-Shuffle-Repeat-for-Flyouts

### DIFF
--- a/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
@@ -39,6 +39,7 @@ addToStores("https://github.com/DevonCasey/tidaluna-plugins/releases/download/la
 addToStores("https://github.com/SinnerK0N/tidaluna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/squadgazzz/luna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/minseokk7/luna-plugins/releases/download/latest/store.json");
+addToStores("https://github.com/FireWall-code/tidaluna-smtc-shuffle-repeat/releases/download/latest/store.json");
 
 export const PluginStoreTab = React.memo(() => {
 	const [_storeUrls, setPluginStores] = useState<string[]>(obyStore.unwrap(storeUrls));


### PR DESCRIPTION
Adds my plugin store to the default list.

Store: https://github.com/FireWall-code/tidaluna-smtc-shuffle-repeat/releases/download/latest/store.json

It contains **TIDAL-Shuffle-Repeat-for-Flyouts**, a plugin that exposes TIDAL's shuffle & repeat (plus title/artist/cover/seekbar) to the Windows System Media Transport Controls, so media/volume flyouts (FluentFlyout, ModernFlyout, the native Windows flyout, lock screen, etc.) can toggle them. Bidirectional sync; optional autostart persistence. The native addon is embedded so the bundle is self-contained.