### PR TITLE
Update FireWall store URL (repo renamed to TidaLuna-Plugins)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.14.0-beta",
+  "version": "1.14.1-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",

--- a/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
@@ -39,7 +39,7 @@ addToStores("https://github.com/DevonCasey/tidaluna-plugins/releases/download/la
 addToStores("https://github.com/SinnerK0N/tidaluna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/squadgazzz/luna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/minseokk7/luna-plugins/releases/download/latest/store.json");
-addToStores("https://github.com/FireWall-code/tidaluna-smtc-shuffle-repeat/releases/download/latest/store.json");
+addToStores("https://github.com/FireWall-code/TidaLuna-Plugins/releases/download/latest/store.json");
 
 export const PluginStoreTab = React.memo(() => {
 	const [_storeUrls, setPluginStores] = useState<string[]>(obyStore.unwrap(storeUrls));


### PR DESCRIPTION
I renamed my plugin store repo from `tidaluna-smtc-shuffle-repeat` to `TidaLuna-Plugins`. This updates the default-store URL accordingly. (GitHub redirects the old URL, but this keeps the list accurate.)