### PR TITLE
Add SongDownloader (ElVigilante) store to default stores

### DIFF
--- a/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
@@ -40,6 +40,7 @@ addToStores("https://github.com/SinnerK0N/tidaluna-plugins/releases/download/lat
 addToStores("https://github.com/squadgazzz/luna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/minseokk7/luna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/FireWall-code/TidaLuna-Plugins/releases/download/latest/store.json");
+addToStores("https://github.com/np3ir/songdownloader-store/releases/download/latest/store.json");
 
 export const PluginStoreTab = React.memo(() => {
 	const [_storeUrls, setPluginStores] = useState<string[]>(obyStore.unwrap(storeUrls));


### PR DESCRIPTION
Adds https://github.com/np3ir/songdownloader-store — a fork of SongDownloader that downloads TIDAL tracks as FLAC with a custom tagging/naming convention (artist separator, featured from /contributors, .lrc sidecar, fullwidth sanitization, {artist_initials} folder, multi-disc handling, m4a tagging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)