### PR TITLE
nix: update pnpm deps hash for the new lib dependencies

### DIFF
--- a/nix/injection-darwin.nix
+++ b/nix/injection-darwin.nix
@@ -21,7 +21,7 @@ in
     pnpmDeps = fetchPnpmDeps {
       inherit pname src version;
       fetcherVersion = 3;
-      hash = "sha256-HhBLCc77SzaG7way8LR8mMGEp0cyuUHqUa8CxKUBDTY=";
+      hash = "sha256-ZvCkGin3EPYg+7QL+6E094+OEV/AcFSgMiRSCW0OV6k=";
     };
 
     buildPhase = ''

--- a/nix/injection-linux.nix
+++ b/nix/injection-linux.nix
@@ -21,7 +21,7 @@ in
     pnpmDeps = fetchPnpmDeps {
       inherit pname src version;
       fetcherVersion = 3;
-      hash = "sha256-HhBLCc77SzaG7way8LR8mMGEp0cyuUHqUa8CxKUBDTY=";
+      hash = "sha256-ZvCkGin3EPYg+7QL+6E094+OEV/AcFSgMiRSCW0OV6k=";
     };
 
     buildPhase = ''


### PR DESCRIPTION
Follow-up to #176: the flake review on that PR flagged a hash mismatch in the `TidaLuna-pnpm-deps` fixed-output derivation, but the report landed right after the merge. Adding mediabunny/node-taglib-sharp to the lockfile changed the pnpm deps hash, so the Nix build on master is currently broken.

This updates the hash in `nix/injection-linux.nix` and `nix/injection-darwin.nix` to the value the CI reported (`got:`).

Generated with [Claude Code](https://claude.com/claude-code)