### PR TITLE
Add tidaluna-plugins store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.15.0-beta",
+  "version": "1.16.0-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",

--- a/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
@@ -40,6 +40,7 @@ addToStores("https://github.com/SinnerK0N/tidaluna-plugins/releases/download/lat
 addToStores("https://github.com/squadgazzz/luna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/minseokk7/luna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/FireWall-code/TidaLuna-Plugins/releases/download/latest/store.json");
+addToStores("https://github.com/FlazeIGuess/tidaluna-plugins/releases/download/latest/store.json");
 
 export const PluginStoreTab = React.memo(() => {
 	const [_storeUrls, setPluginStores] = useState<string[]>(obyStore.unwrap(storeUrls));


### PR DESCRIPTION
Adds the store for Star Ratings, interactive 5-star song ratings for TIDAL (a TidaLuna port of spicetify-star-ratings).

Store: https://github.com/FlazeIGuess/tidaluna-plugins/releases/download/latest/store.json
Repo: https://github.com/FlazeIGuess/tidaluna-plugins