### PR TITLE
Fix CI build: move pnpm overrides to pnpm-workspace.yaml (pnpm v10+)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,5 @@
     "clean-css": "^5.3.3",
     "esbuild": "^0.27.1",
     "html-minifier-terser": "^7.2.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "yaml@<1.10.3": ">=1.10.3"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,6 @@ packages:
  - "./native"
  - "./render"
  - "./plugins/*"
+
+overrides:
+ yaml@<1.10.3: ">=1.10.3"


### PR DESCRIPTION
## Problem

The `[master] Release` workflow fails at **Install dependencies** with:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides".
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation. The current "overrides" configuration doesn't match the value found in the lockfile
```

## Cause

pnpm v10+ no longer reads the `pnpm.overrides` field from `package.json` - it moved to `pnpm-workspace.yaml` (https://pnpm.io/settings). The CI installs `pnpm@latest` via `pnpm/action-setup@v4` and there is no `packageManager` pin, so the new pnpm ignores the override. The lockfile still records `overrides: { yaml@<1.10.3: '>=1.10.3' }`, so the frozen install aborts with a config mismatch.

## Fix

Move the single override from `package.json` to `pnpm-workspace.yaml`. The value is unchanged, so it matches what the lockfile already records - no relock needed.

## Verification

Reproduced the failure on the current master commit with pnpm 10/11, then confirmed `CI=true pnpm install --frozen-lockfile` completes with exit 0 after the change.