### PR TITLE
Fix CI build: allow dependency build scripts (pnpm v11 allowBuilds)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,8 @@ packages:
 
 overrides:
  yaml@<1.10.3: ">=1.10.3"
+
+allowBuilds:
+ "@biomejs/biome": true
+ electron: true
+ esbuild: true


### PR DESCRIPTION
## Problem

With #180 merged, the `[master] Release` build now gets past the overrides error and fails at the next step, **Install dependencies**:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @biomejs/biome@1.9.4, electron@38.8.6, esbuild@0.27.1
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

## Cause

pnpm v10+ blocks dependency build scripts by default for security. The CI installs `pnpm@latest` (currently v11) via `pnpm/action-setup@v4`, which requires an explicit allow-list. In pnpm v11 this is the `allowBuilds` map in `pnpm-workspace.yaml` (pnpm even writes a stub prompting `set this to true or false` for each package). Without it, the install aborts with exit 1.

## Fix

Add `allowBuilds` to `pnpm-workspace.yaml` with the three packages that ship postinstall scripts set to `true`:

```yaml
allowBuilds:
 "@biomejs/biome": true
 electron: true
 esbuild: true
```

## Verification

On a clean checkout (empty `node_modules`), mirroring CI:

- `CI=true pnpm install --frozen-lockfile` -> exit 0 (all three postinstalls run: electron, esbuild, biome)
- `pnpm run build` -> exit 0 (injector + luna.dev/lib/ui built)

`pnpm-lock.yaml` is unchanged, so no relock is needed.

> Note: the root cause of this and #180 is that the workflow installs `pnpm@latest`, so each pnpm behavior change can break CI. Pinning pnpm (e.g. a `packageManager` field or a fixed `version:` in the workflow) would prevent future surprises. Happy to send that as a follow-up if wanted.