### PR TITLE
Bump version to 1.16.1-beta (trigger release build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luna",
-  "version": "1.16.0-beta",
+  "version": "1.16.1-beta",
   "description": "A client mod for the Tidal music app for plugins",
   "author": {
     "name": "Inrixia",


### PR DESCRIPTION
Bumps the root `version` from `1.16.0-beta` to `1.16.1-beta`.

### Why
The `[master] Release` workflow only runs on pushes to `master` that touch `package.json` (its `paths:` filter). Because of that:

- The release build had been failing since before #180, so the `1.15.0-beta` and `1.16.0-beta` version bumps never actually produced a GitHub release. The latest published release is still `1.14.0-beta`.
- #180 (pnpm overrides -> `pnpm-workspace.yaml`) and #181 (pnpm v11 `allowBuilds`) fixed the CI, but #181 only changed `pnpm-workspace.yaml`, so it did not re-trigger `[master] Release`. There has been no release run since the fix landed.

This one-line version bump is the minimal `package.json` change needed to re-trigger `[master] Release` now that CI is fixed. On merge it should build cleanly and publish the pending `1.16.1-beta` release.

No functional changes.