### PR TITLE
Remove dead store: DevonCasey/tidaluna-plugins (404)

### DIFF
--- a/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
+++ b/plugins/ui/src/SettingsPage/PluginStoreTab/index.tsx
@@ -35,7 +35,6 @@ addToStores("https://github.com/Akasiek/tidaluna-plugins/releases/download/lates
 addToStores("https://github.com/Foukapik/TidaLuna-Plugins/releases/download/latest/store.json");
 addToStores("https://github.com/Renskursa/tidaluna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/Henr1ES/TidalLunaPlugins/releases/download/latest/store.json");
-addToStores("https://github.com/DevonCasey/tidaluna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/SinnerK0N/tidaluna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/squadgazzz/luna-plugins/releases/download/latest/store.json");
 addToStores("https://github.com/minseokk7/luna-plugins/releases/download/latest/store.json");


### PR DESCRIPTION
Removes the `DevonCasey/tidaluna-plugins` entry from the default store list in `PluginStoreTab`.

The whole repository `github.com/DevonCasey/tidaluna-plugins` now returns **404** - not just the release asset. It was deleted, renamed, or made private, so its `store.json` can never resolve. Every TidaLuna client currently tries to fetch this dead URL on the Plugin Store tab.

Verified: `https://github.com/DevonCasey/tidaluna-plugins` -> 404, and the GitHub API reports `Not Found` for the repo's releases.

The remaining 20 default stores were all checked and still return a valid `store.json` (HTTP 200).

No other changes.